### PR TITLE
feat(error-handler-middleware): render unauthorized error if error status is 401 too

### DIFF
--- a/app/middlewares/error-handler.js
+++ b/app/middlewares/error-handler.js
@@ -21,7 +21,7 @@ module.exports = function(errorPage) {
     try {
       yield next;
     } catch (ex) {
-      if (ex.code === 401) {
+      if (ex.code === 401 || ex.status === 401) {
         this.status = 401;
         renderError(this, 'We\'re sorry, but You are not authorized to take this action');
         logger.error('authentication', ex.message);

--- a/app/middlewares/error-handler.spec.js
+++ b/app/middlewares/error-handler.spec.js
@@ -6,6 +6,7 @@ var errorHandler = require('./error-handler');
 describe('Error Handler Middleware', function() {
 
   const DEFAULT_ERROR_MESSAGE = 'We\'re sorry, but something went wrong';
+  const UNAUTHORIZED_ERROR_MESSAGE = 'We\'re sorry, but You are not authorized to take this action';
   const ERROR_PAGE_PATH = 'path/to/error/page';
 
   let fakeContext;
@@ -46,6 +47,40 @@ describe('Error Handler Middleware', function() {
     yield middleware.call(fakeContext, nextError);
 
     expect(fakeContext.body).to.eql(DEFAULT_ERROR_MESSAGE);
+  });
+
+  ['code', 'status'].forEach(propertyName => {
+
+    describe(`error ${propertyName} is 401`, function () {
+
+      it('should render unauthorized message to request body if no error page path specified', function* () {
+        var middleware = errorHandler();
+        let unauthorizedError = function* () {
+          let error = new Error();
+          error[propertyName] = 401;
+          throw error;
+        };
+
+        yield middleware.call(fakeContext, unauthorizedError);
+
+        expect(fakeContext.body).to.eql(UNAUTHORIZED_ERROR_MESSAGE);
+      });
+
+      it('should render unauthorized message to error page if specified', function* () {
+        var middleware = errorHandler();
+        let unauthorizedError = function* () {
+          let error = new Error();
+          error[propertyName] = 401;
+          throw error;
+        };
+
+        yield middleware.call(fakeContext, unauthorizedError);
+
+        expect(fakeContext.body).to.eql(UNAUTHORIZED_ERROR_MESSAGE);
+      });
+
+    });
+
   });
 
 });


### PR DESCRIPTION
Using this.throw(401) with koa results in an Error that has 401 as Error.status instead of Error.code.
This is for allowing such errors to be rendered properly with the unauthorized error page.
