### PR TITLE
feat(app): add close method for closing server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Boar Server 
+# Boar Server
 
 ## Example usage for app
 
@@ -26,6 +26,19 @@ put these lines in your server.js
   var cors = require('koa-cors');
   var app = new App(koaApp);
   app.addMiddleware(cors());
+```
+
+## Graceful shutdown
+You can stop the server from recieving new connections with `app.close()`. It returns a Promise that resolves when all existing connections are ended.
+``` javascript
+  var app = new App(koaApp);
+  app.listen(config.port);
+  process.on('SIGTERM', () => {
+    app.close().then(() => {
+      // additional cleaning (e.g. closing db connection)
+      process.exit(0);
+    })
+  })
 ```
 
 ## HTTPS support
@@ -208,7 +221,7 @@ Provides middlewares for setting up various security related HTTP headers.
 
 ```javascript
   var clearCollections = require('boar-server').lib.clearCollections(mongoose);
-  
+
   clearCollections(); // returns a promise
 ```
 
@@ -218,7 +231,7 @@ This will _drop_ all your collections.
 
 ```javascript
   var truncateCollections = require('boar-server').lib.truncateCollections(mongoose);
-  
+
   truncateCollections(); // returns a promise
 ```
 

--- a/app/index.spec.js
+++ b/app/index.spec.js
@@ -1,0 +1,101 @@
+'use strict';
+
+const http = require('http');
+const https = require('https');
+const expect = require('chai').expect;
+const sinon = require('sinon');
+const App = require('./');
+
+let sandbox;
+
+const createFakeServer = extensions => {
+  const defaultFakeServer = {
+    listen() {
+      return this;
+    },
+    close: sandbox.stub()
+  };
+  return Object.assign(defaultFakeServer, extensions);
+};
+
+const createApp = () => new App({ callback: () => {} });
+
+const tick = () => {
+  return new Promise(resolve => setTimeout(resolve, 0));
+};
+
+
+describe('App', () => {
+
+  let envSnapshot;
+
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+    envSnapshot = Object.assign({}, process.env);
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+    process.env = envSnapshot;
+  });
+
+  describe('#close', () => {
+
+    it('should close the running servers', function() {
+      process.env.SERVE_HTTPS = 'true';
+      const httpServer = createFakeServer();
+      sandbox.stub(http, 'createServer').returns(httpServer);
+      const httpsServer = createFakeServer();
+      sandbox.stub(https, 'createServer').returns(httpsServer);
+      const app = createApp();
+      app.listen(3000);
+
+      app.close();
+
+      expect(httpServer.close).to.have.been.calledOnce;
+      expect(httpsServer.close).to.have.been.calledOnce;
+    });
+
+
+    it('should return a promise that resolves after all servers had closed', function* () {
+      process.env.SERVE_HTTPS = 'true';
+
+      let httpServerClosedCallback;
+      const httpServer = createFakeServer({ close: callback => httpServerClosedCallback = callback });
+      sandbox.stub(http, 'createServer').returns(httpServer);
+
+      let httpsServerClosedCallback;
+      const httpsServer = createFakeServer({ close: callback => httpsServerClosedCallback = callback });
+      sandbox.stub(https, 'createServer').returns(httpsServer);
+
+      const app = createApp();
+      app.listen(3000);
+
+      let closeResolved = false;
+      app.close().then(() => closeResolved = true);
+
+      httpServerClosedCallback();
+      yield tick();
+      expect(closeResolved).to.be.false;
+
+      httpsServerClosedCallback();
+      yield tick();
+      expect(closeResolved).to.be.true;
+    });
+
+
+    it('should not call close on already closed servers', function() {
+      const httpServer = createFakeServer();
+      sandbox.stub(http, 'createServer').returns(httpServer);
+      const app = createApp();
+      app.listen(3000);
+
+      app.close();
+      app.close();
+
+      expect(httpServer.close).to.have.been.calledOnce;
+    });
+
+  });
+
+});

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "mocha": "3.0.2",
     "nsp": "2.6.1",
     "semantic-release": "4.3.5",
-    "sinon": "1.17.5"
+    "sinon": "1.17.5",
+    "sinon-chai": "2.12.0"
   },
   "dependencies": {
     "app-root-path": "1.3.0",

--- a/setup-test.spec.js
+++ b/setup-test.spec.js
@@ -1,0 +1,4 @@
+const sinonChai = require('sinon-chai');
+const chai = require('chai');
+
+before(() => chai.use(sinonChai));


### PR DESCRIPTION
The Editor Core team would like to implement graceful shutdown, but currently the Boar Server doesn't expose anything to close the servers.
Please accept this pull request to let us have peaceful, alertless nights again. :)